### PR TITLE
Make startest a dev dependency

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -7,7 +7,7 @@ repository = { type = "github", user = "Pevensie", repo = "argus" }
 
 [dependencies]
 gleam_stdlib = ">= 0.34.0 and < 2.0.0"
-startest = ">= 0.4.0 and < 1.0.0"
 jargon = ">= 1.0.0 and < 2.0.0"
 
 [dev-dependencies]
+startest = ">= 0.4.0 and < 1.0.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -26,5 +26,5 @@ packages = [
 
 [requirements]
 gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
-jargon = { version = ">= 1.0.0 and < 2.0.0"}
-startest = { version = ">= 0.4.0 and < 1.0.0" }
+jargon = { version = ">= 1.0.0 and < 2.0.0" }
+startest = { version = ">= 0.4.0 and < 1.0.0"}


### PR DESCRIPTION
I have the same issue as in #2 , seems reasonable to me that startest would be a dev dependency so opening this one :smiley_cat: 

Closes #2 